### PR TITLE
adapt aptly source to be compatible with new apt::source

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,9 +69,9 @@ class aptly (
 
   if $repo {
     apt::source { 'aptly':
-      location   => 'http://repo.aptly.info',
-      release    => 'squeeze',
-      repos      => 'main',
+      location => 'http://repo.aptly.info',
+      release  => 'squeeze',
+      repos    => 'main',
       key      => {
         id     => 'DF32BC15E2145B3FA151AED19E3E53F19C7DE460',
         server => $key_server,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,8 +72,10 @@ class aptly (
       location   => 'http://repo.aptly.info',
       release    => 'squeeze',
       repos      => 'main',
-      key_server => $key_server,
-      key        => 'DF32BC15E2145B3FA151AED19E3E53F19C7DE460',
+      key      => {
+        id     => 'DF32BC15E2145B3FA151AED19E3E53F19C7DE460',
+        server => $key_server,
+      },
     }
 
     Apt::Source['aptly'] -> Class['apt::update'] -> Package['aptly']


### PR DESCRIPTION
this fixes the following error:
```
Server Error: Evaluation Error: Error while evaluating a Resource Statement, Apt::Source[aptly]: has no parameter named 'key_server' at /etc/puppetlabs/code/modules/aptly/manifests/init.pp:71
```

also made PR upstream